### PR TITLE
[REFACTOR] DB 쿼리 최적화 및 N+1 개선 (#267)

### DIFF
--- a/apps/api/src/battle/battle.service.ts
+++ b/apps/api/src/battle/battle.service.ts
@@ -511,15 +511,17 @@ export class BattleService {
     const winnerId = opponent.userId;
     const loserId = forfeiterUserId;
 
-    // 마지막 제출 기록 조회 (있으면 저장)
-    const winnerSubmission = await this.submissionRepository.findOne({
-      where: { battleId: battle.battleId, userId: winnerId },
-      order: { createdAt: 'DESC' },
-    });
-    const loserSubmission = await this.submissionRepository.findOne({
-      where: { battleId: battle.battleId, userId: loserId },
-      order: { createdAt: 'DESC' },
-    });
+    // 마지막 제출 기록 조회
+    const [winnerSubmission, loserSubmission] = await Promise.all([
+      this.submissionRepository.findOne({
+        where: { battleId: battle.battleId, userId: winnerId },
+        order: { createdAt: 'DESC' },
+      }),
+      this.submissionRepository.findOne({
+        where: { battleId: battle.battleId, userId: loserId },
+        order: { createdAt: 'DESC' },
+      }),
+    ]);
 
     // 트랜잭션으로 DB 작업 수행 (레이팅 업데이트 + 배틀 저장)
     const savedBattle = await this.dataSource.transaction(async (manager) => {

--- a/apps/api/src/room/room.gateway.ts
+++ b/apps/api/src/room/room.gateway.ts
@@ -452,7 +452,7 @@ export class RoomGateway {
     if (now - lastSent < 1000) return;
     this.cheatWarningMap.set(throttleKey, now);
 
-    const maxWarnings = 100;
+    const maxWarnings = 5;
     const currentCount = this.cheatCountMap.get(throttleKey) ?? 0;
     const nextCount = Math.min(maxWarnings, currentCount + 1);
     this.cheatCountMap.set(throttleKey, nextCount);

--- a/apps/api/src/submission/submission.entity.ts
+++ b/apps/api/src/submission/submission.entity.ts
@@ -1,8 +1,8 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
-@Index(['battleId', 'userId'])
-@Index(['userId', 'createdAt'])
+@Index(['battleId', 'userId', 'createdAt'])
+@Index(['userId', 'battleId', 'createdAt'])
 export class Submission {
   @PrimaryGeneratedColumn()
   id: string;

--- a/apps/api/src/submission/submission.entity.ts
+++ b/apps/api/src/submission/submission.entity.ts
@@ -1,6 +1,8 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
+@Index(['battleId', 'userId'])
+@Index(['userId', 'createdAt'])
 export class Submission {
   @PrimaryGeneratedColumn()
   id: string;

--- a/apps/api/src/submission/submission.service.ts
+++ b/apps/api/src/submission/submission.service.ts
@@ -28,6 +28,7 @@ export class SubmissionService {
   ): Promise<SubmissionDetail | null> {
     const submission = await this.submissionRepository.findOne({
       where: { id: submissionId, userId },
+      select: ['id', 'code', 'language', 'problemId'],
     });
 
     if (!submission) {
@@ -36,6 +37,18 @@ export class SubmissionService {
 
     const problem = await this.problemRepository.findOne({
       where: { id: submission.problemId },
+      select: [
+        'title',
+        'source',
+        'difficulty',
+        'tags',
+        'timeLimit',
+        'memoryLimit',
+        'statement',
+        'input',
+        'output',
+        'examples',
+      ],
     });
 
     if (!problem) {

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -210,6 +210,13 @@ export class UserService {
       }),
       this.submissionRepository
         .createQueryBuilder('submission')
+        .select([
+          'submission.battleId',
+          'submission.language',
+          'submission.passedTestCases',
+          'submission.totalTestCases',
+          'submission.createdAt',
+        ])
         .where('submission.userId = :userId', { userId })
         .andWhere('submission.battleId IN (:...battleIds)', { battleIds })
         .orderBy('submission.createdAt', 'DESC')

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -4,7 +4,7 @@ import { clampRating, getTierFromRating, RATING_CONFIG } from '@packages/constan
 import { BattleHistoryItem, SubmissionHistoryItem } from '@packages/types/user';
 import { Glicko2, newProcedure } from 'glicko2.ts';
 import Redis from 'ioredis';
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager, In, Repository } from 'typeorm';
 
 import { Battle } from '@/battle/battle.entity';
 import { Problem } from '@/problem/problem.entity';
@@ -172,65 +172,101 @@ export class UserService {
 
   // 사용자 배틀 기록 조회
   async getBattleHistory(userId: string): Promise<BattleHistoryItem[]> {
+    // 배틀 목록 조회
     const battles = await this.battleRepository
       .createQueryBuilder('battle')
       .where('FIND_IN_SET(:userId, battle.playerIds) > 0', { userId })
       .orderBy('battle.createdAt', 'DESC')
       .getMany();
 
-    const historyWithDetails = await Promise.all(
-      battles.map(async (battle) => {
-        // 결과 판별
-        let result: 'WIN' | 'LOSS' | 'DRAW' = 'DRAW';
-        if (battle.winnerId) {
-          result = battle.winnerId === userId ? 'WIN' : 'LOSS';
-        }
+    if (battles.length === 0) {
+      return [];
+    }
 
-        // 상대방 이름
-        const opponentId = battle.playerIds.find((id) => id !== userId);
-        const opponent = opponentId
-          ? await this.userRepository.findOne({ where: { id: opponentId }, select: ['username'] })
-          : null;
+    // 필요한 ID 수집
+    const opponentIds = [
+      ...new Set(
+        battles
+          .map((b) => b.playerIds.find((id) => id !== userId))
+          .filter((id): id is string => !!id),
+      ),
+    ];
+    const problemIds = [...new Set(battles.map((b) => b.problemId))];
+    const battleIds = battles.map((b) => b.id);
 
-        // 문제 정보
-        const problem = await this.problemRepository.findOne({
-          where: { id: battle.problemId },
-          select: ['title', 'difficulty', 'testcases'],
-        });
+    // 한 번에 조회
+    const opponents: Pick<User, 'id' | 'username'>[] =
+      opponentIds.length > 0
+        ? await this.userRepository.find({
+            where: { id: In(opponentIds) },
+            select: ['id', 'username'],
+          })
+        : [];
 
-        // 내 최종 제출 정보
-        const mySubmission = await this.submissionRepository.findOne({
-          where: { userId, battleId: battle.id },
-          order: { createdAt: 'DESC' },
-        });
-
-        // 점수 변화량
-        const playerIndex = battle.playerIds.indexOf(userId);
-        const ratingChange =
-          playerIndex === 0 ? battle.player1RatingChange : battle.player2RatingChange;
-
-        return {
-          id: battle.id,
-          result,
-          opponentName: opponent?.username || '알 수 없는 유저',
-          problem: {
-            title: problem?.title || '삭제된 문제',
-            difficulty: problem?.difficulty || 'Unknown',
-          },
-          submission: mySubmission
-            ? {
-                language: mySubmission.language,
-                passedTestCases: mySubmission.passedTestCases,
-                totalTestCases: mySubmission.totalTestCases ?? (problem?.testcases?.length || 0),
-              }
-            : null,
-          ratingChange: ratingChange || 0,
-          createdAt: battle.createdAt,
-        };
+    const [problems, submissions] = await Promise.all([
+      this.problemRepository.find({
+        where: { id: In(problemIds) },
+        select: ['id', 'title', 'difficulty', 'testcases'],
       }),
-    );
+      this.submissionRepository
+        .createQueryBuilder('submission')
+        .where('submission.userId = :userId', { userId })
+        .andWhere('submission.battleId IN (:...battleIds)', { battleIds })
+        .orderBy('submission.createdAt', 'DESC')
+        .getMany(),
+    ]);
 
-    return historyWithDetails;
+    const opponentMap = new Map(opponents.map((u) => [u.id, u] as const));
+    const problemMap = new Map(problems.map((p) => [p.id, p] as const));
+    // 각 배틀당 가장 최근 제출만 매핑
+    const submissionMap = new Map<string, Submission>();
+    for (const sub of submissions) {
+      if (!submissionMap.has(sub.battleId)) {
+        submissionMap.set(sub.battleId, sub);
+      }
+    }
+
+    // 결과 조합
+    return battles.map((battle) => {
+      let result: 'WIN' | 'LOSS' | 'DRAW' = 'DRAW';
+      if (battle.winnerId) {
+        result = battle.winnerId === userId ? 'WIN' : 'LOSS';
+      }
+
+      // 상대방 정보
+      const opponentId = battle.playerIds.find((id) => id !== userId);
+      const opponent = opponentId ? opponentMap.get(opponentId) : null;
+
+      // 문제 정보
+      const problem = problemMap.get(battle.problemId);
+
+      // 내 제출 정보
+      const mySubmission = submissionMap.get(battle.id);
+
+      // 점수 변화량
+      const playerIndex = battle.playerIds.indexOf(userId);
+      const ratingChange =
+        playerIndex === 0 ? battle.player1RatingChange : battle.player2RatingChange;
+
+      return {
+        id: battle.id,
+        result,
+        opponentName: opponent?.username || '알 수 없는 유저',
+        problem: {
+          title: problem?.title || '삭제된 문제',
+          difficulty: problem?.difficulty || 'Unknown',
+        },
+        submission: mySubmission
+          ? {
+              language: mySubmission.language,
+              passedTestCases: mySubmission.passedTestCases,
+              totalTestCases: mySubmission.totalTestCases ?? (problem?.testcases?.length || 0),
+            }
+          : null,
+        ratingChange: ratingChange || 0,
+        createdAt: battle.createdAt,
+      };
+    });
   }
 
   // 마이페이지 제출 이력 조회

--- a/apps/web/src/components/Battle/modals/LeaveBattleModal.tsx
+++ b/apps/web/src/components/Battle/modals/LeaveBattleModal.tsx
@@ -16,8 +16,8 @@ export default function LeaveBattleModal({ isOpen, onCancel, onConfirm }: LeaveB
       icon={AlertCircle}
       iconColor="text-error-01"
       iconBgColor="bg-error-01/20"
-      title="대결에서 나가시겠습니까?"
-      description="진행 중인 문제 풀이가 모두 사라집니다."
+      title="배틀을 포기하시겠습니까?"
+      description="나가면 기권 패배 처리되며, 레이팅이 하락합니다."
       buttons={[
         {
           label: '취소',

--- a/apps/web/src/components/Battle/modals/LeaveBattleModal.tsx
+++ b/apps/web/src/components/Battle/modals/LeaveBattleModal.tsx
@@ -25,7 +25,7 @@ export default function LeaveBattleModal({ isOpen, onCancel, onConfirm }: LeaveB
           variant: 'muted',
         },
         {
-          label: '나가기',
+          label: '포기하기',
           onClick: onConfirm,
           variant: 'black',
         },


### PR DESCRIPTION
## 🔍 PR 요약

- 배틀 히스토리 조회 시 발생하던 N+1 쿼리 문제를 배치 조회 방식으로 개선
- Submission 엔티티에 복합 인덱스 추가 및 불필요한 컬럼 select 제거
- forfeitBattle 제출 조회 병렬화

## 🧾 관련 이슈

- close #267 

## 🛠️ 주요 변경 사항

- `getBattleHistory` N+1 쿼리 해결

  - 기존에는 배틀 목록을 가져온 뒤 각 배틀에 대해 상대방 정보, 문제 정보, 내 최신 제출 조회 
    → 배틀 n개에 대해 총 `1 + 3n`번의 쿼리가 발생하는 구조
  - 배틀 목록에서 필요한 ID(상대방 ID, 문제 ID, 배틀 ID)를 먼저 수집하여 한 번에 배치 조회, O(1)로 매핑하도록 변경
  - 쿼리 수가 배틀 수와 무관하게 4개로 고정

- **`Submission` 엔티티 복합 인덱스 추가**

  - 배치 조회에서 자주 사용하는 조건인 `(battleId, userId)`와 `(userId, createdAt)` 조합에 복합 인덱스 추가

- **`getSubmissionDetail` 컬럼 select 최적화**

  - 기존엔 submission과 problem 조회 시 모든 컬럼을 가져오던 방식
  - 실제로 응답에 사용하는 컬럼만 명시적으로 select하도록 변경
  - problem 엔티티의 경우 testcases 등 크기가 큰 컬럼이 불필요하게 전송되고 있었음

- **`forfeitBattle` 제출 조회 병렬화**

  - 포기 처리 시 승자와 패자의 마지막 제출 기록을 순차적으로 조회하던 방식을 `Promise.all`로 병렬 실행하도록 변경

## 🧠 의도 및 배경

- 배틀 기록이 쌓일수록 히스토리 조회 응답이 느려지는 문제 발생 
- 쿼리 수가 데이터 수에 비례해 선형으로 증가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **성능 개선**
  * 전투 기록 및 제출 정보 조회 최적화로 로딩 속도 향상

* **밸런스 조정**
  * 부정행위 경고 임계값 변경으로 더 신속한 시스템 대응

* **UI 개선**
  * 전투 포기 모달 메시지 업데이트: 포기 시 패배 및 등급 감소 명시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->