### PR TITLE
[FIX] 소켓 재연결 실패 시 메인 페이지 이동 및 토스트 알림 추가 (#281)

### DIFF
--- a/apps/web/src/components/Battle/BattleProblem.tsx
+++ b/apps/web/src/components/Battle/BattleProblem.tsx
@@ -157,12 +157,12 @@ function BattleProblem() {
               {exampleItems.map((ex) => (
                 <div key={ex.label} className="space-y-2 rounded-md bg-base-primary/5 p-3 text-sm">
                   <p className="text-sm font-bold text-base-secondary">{ex.label}</p>
-                  <p className="text-sm">
+                  <div className="text-sm">
                     입력: <pre className="text-green-05">{ex.input}</pre>
-                  </p>
-                  <p className="text-sm">
+                  </div>
+                  <div className="text-sm">
                     출력: <pre className="text-green-05">{ex.output}</pre>
-                  </p>
+                  </div>
                 </div>
               ))}
             </div>

--- a/apps/web/src/hooks/useBattleJoin.ts
+++ b/apps/web/src/hooks/useBattleJoin.ts
@@ -19,6 +19,7 @@ type UseBattleJoinParams = {
   resumeSession: BattleSocketState['resumeSession'];
   joinRoom: BattleSocketState['joinRoom'];
   onInvalidRole: () => void;
+  onRoomNotFound?: () => void;
 };
 
 export function useBattleJoin({
@@ -31,6 +32,7 @@ export function useBattleJoin({
   resumeSession,
   joinRoom,
   onInvalidRole,
+  onRoomNotFound,
 }: UseBattleJoinParams) {
   const userRef = useRef(user);
 
@@ -75,28 +77,37 @@ export function useBattleJoin({
   ]);
 
   useEffect(() => {
-    const handleReconnect = () => {
+    const handleReconnect = async () => {
       if (isRoleMismatch) return;
       // 소켓 재연결 시 저장된 세션 기준으로 다시 JOIN_ROOM 시도
-      resumeSession({ roleHint: desiredRole })
-        .catch(() => {})
-        .then(() => {
-          if (!useRoomStore.getState().me) {
-            const currentUser = userRef.current;
-            joinRoom({
-              roomId,
-              requestedRole: desiredRole,
-              userId: currentUser?.id,
-              username: currentUser?.username,
-              avatarUrl: currentUser?.avatarUrl,
-            }).catch((error) => {
-              const code = (error as Error & { code?: string }).code;
-              if (code === SOCKET_ERROR.INVALID_ROLE) {
-                onInvalidRole();
-              }
-            });
+      try {
+        await resumeSession({ roleHint: desiredRole });
+      } catch (error) {
+        const code = (error as Error & { code?: string }).code;
+        if (code === SOCKET_ERROR.ROOM_NOT_FOUND) {
+          onRoomNotFound?.();
+          return;
+        }
+      }
+      if (!useRoomStore.getState().me) {
+        const currentUser = userRef.current;
+        try {
+          await joinRoom({
+            roomId,
+            requestedRole: desiredRole,
+            userId: currentUser?.id,
+            username: currentUser?.username,
+            avatarUrl: currentUser?.avatarUrl,
+          });
+        } catch (error) {
+          const code = (error as Error & { code?: string }).code;
+          if (code === SOCKET_ERROR.INVALID_ROLE) {
+            onInvalidRole();
+          } else if (code === SOCKET_ERROR.ROOM_NOT_FOUND) {
+            onRoomNotFound?.();
           }
-        });
+        }
+      }
     };
     socket.on('connect', handleReconnect);
     return () => {

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -305,7 +305,7 @@ function BattlePage() {
     onInvalidRole: handleInvalidRole,
     onRoomNotFound: () => {
       forceNavigateRef.current = true;
-      navigate('/', { replace: true });
+      navigate('/', { replace: true, state: { toast: '연결이 끊어져 배틀이 종료되었습니다.' } });
     },
   });
 

--- a/apps/web/src/pages/BattlePage.tsx
+++ b/apps/web/src/pages/BattlePage.tsx
@@ -83,6 +83,7 @@ function BattlePage() {
   >(null);
   const showSystemToast = useBattleToastStore((state) => state.show);
   const lastCheatSentAtRef = useRef(0);
+  const forceNavigateRef = useRef(false);
 
   const [showFinishOverlay, setShowFinishOverlay] = useState(false);
   const [showLeaveModal, setShowLeaveModal] = useState(false);
@@ -115,6 +116,7 @@ function BattlePage() {
       !isSpectator &&
       !!battleId &&
       !isLeavingBattle &&
+      !forceNavigateRef.current &&
       currentLocation.pathname !== nextLocation.pathname,
   );
 
@@ -301,6 +303,10 @@ function BattlePage() {
     resumeSession,
     joinRoom,
     onInvalidRole: handleInvalidRole,
+    onRoomNotFound: () => {
+      forceNavigateRef.current = true;
+      navigate('/', { replace: true });
+    },
   });
 
   const handleRoleDenied = () => {

--- a/apps/web/src/pages/MainPage.tsx
+++ b/apps/web/src/pages/MainPage.tsx
@@ -1,8 +1,9 @@
 import { Info, LogIn } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import Modal from '@/components/Common/Modal';
+import Toast from '@/components/Common/Toast';
 import Header from '@/components/Header/Header';
 import RoomCardList from '@/components/Main/RoomCardList';
 import { useBattleSocketStore } from '@/stores/battleSocketStore';
@@ -20,7 +21,17 @@ const tierFilters = [
 
 function MainPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const user = useUserStore((state) => state.user);
+  const [toastMessage, setToastMessage] = useState<string | null>(
+    (location.state as { toast?: string } | null)?.toast ?? null,
+  );
+
+  useEffect(() => {
+    if (location.state?.toast) {
+      window.history.replaceState({}, '');
+    }
+  }, []);
 
   const connect = useBattleSocketStore((state) => state.connect);
   const subscribeRoomList = useBattleSocketStore((state) => state.subscribeRoomList);
@@ -107,6 +118,9 @@ function MainPage() {
   return (
     <div className="min-h-screen bg-bg-layer-1">
       <Header />
+      {toastMessage && (
+        <Toast message={toastMessage} onClose={() => setToastMessage(null)} duration={3000} />
+      )}
       <main className="mx-auto flex max-w-6xl flex-col gap-8 px-4 pb-16 pt-10 lg:px-8">
         {/* 상단 헤더 */}
         <div className="flex flex-col gap-1">


### PR DESCRIPTION
## 🔍 PR 요약

- 소켓 재연결 시 방이 존재하지 않을 경우 메인 페이지로 이동하고 토스트 알림 표시
- `p` 태그 내 `pre` 태그 중첩으로 인한 HTML 유효성 오류 수정

## 🧾 관련 이슈

- close #281 

## 🛠️ 주요 변경 사항

- 소켓 재연결 실패 처리

  - 소켓 재연결 시 `ROOM_NOT_FOUND` 에러를 감지할 수 있도록 `handleReconnect`를 `async/await`로 리팩토링
  - `ROOM_NOT_FOUND` 에러 코드를 감지했을 때 `onRoomNotFound` 콜백을 호출하도록 변경
  - `BattlePage`에서는 `onRoomNotFound` 콜백에서 `forceNavigateRef`를 `true`로 설정해 "배틀 나가기 확인 모달"이 뜨는 것을 막기 위해 도입
  - 이동 시 `location.state`에 토스트 메시지를 담아 메인 페이지로 이동

- 메인 페이지 토스트 알림

  - `MainPage`에서 `location.state.toast` 값이 있으면 토스트를 노출하도록 추가
  - 토스트 메시지를 읽은 직후 `window.history.replaceState`로 state를 초기화해 새로고침 시 재노출되지 않도록 처리

- `p > pre` 중첩 HTML 오류 수정

  - `BattleProblem` 예제 입출력 영역에서 인라인 요소인 `<p>` 안에 블록 요소인 `<pre>`가 중첩되어 HTML 유효성 오류 발생
  - `<p>`를 `<div>`로 교체

## 📸 스크린샷

<img width="1916" height="904" alt="화면 녹화 중 2026-04-15 111803" src="https://github.com/user-attachments/assets/3c4369da-a05e-4046-ab75-29cb1e201f9a" />

## 🧠 의도 및 배경

- 배틀 중 네트워크가 끊기거나 서버가 재시작되면 소켓이 재연결을 시도하는데, 이때 해당 방이 이미 사라진 경우 사용자가 아무런 안내 없이 배틀 화면에 머물게 되는 문제 발생
- 재연결 실패 상황을 명확히 감지해 사용자에게 안내하고 정상 상태로 복귀시키는 것이 목적

