### PR TITLE
[FIX] 코드 실행 시 마지막 테스트케이스 간헐적 누락 버그 수정 (#282)

### DIFF
--- a/apps/api/src/pubsub/pubsub-subscriber.service.ts
+++ b/apps/api/src/pubsub/pubsub-subscriber.service.ts
@@ -17,6 +17,7 @@ import { PubsubGateway } from './pubsub.gateway';
 export class PubsubSubscriberService implements OnModuleInit {
   private readonly logger = new Logger(PubsubSubscriberService.name);
   private readonly subscriber: Redis;
+  private readonly queues = new Map<string, Promise<void>>();
 
   constructor(
     @Inject(REDIS_CLIENT) private readonly redisClient: Redis,
@@ -33,8 +34,20 @@ export class PubsubSubscriberService implements OnModuleInit {
     this.logger.log(`Subscribed to channel: ${PUBSUB_CHANNELS.SUBMISSION_RESULT}`);
 
     this.subscriber.on('message', (channel, message) => {
-      void this.handleMessage(channel, message);
+      const parsed = JSON.parse(message) as { submissionId: string };
+      const submissionId = String(parsed.submissionId);
+      this.enqueue(submissionId, () => this.handleMessage(channel, message));
     });
+  }
+
+  private enqueue(submissionId: string, task: () => Promise<void>): void {
+    const prev = this.queues.get(submissionId) ?? Promise.resolve();
+    const next = prev.then(task).finally(() => {
+      if (this.queues.get(submissionId) === next) {
+        this.queues.delete(submissionId);
+      }
+    });
+    this.queues.set(submissionId, next);
   }
 
   private async handleMessage(channel: string, message: string) {

--- a/apps/api/test/pubsub/pubsub-subscriber.service.spec.ts
+++ b/apps/api/test/pubsub/pubsub-subscriber.service.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import RedisMock from 'ioredis-mock';
+
+import { BattleGateway } from '@/battle/battle.gateway';
+import { BattleService } from '@/battle/battle.service';
+import { PubsubGateway } from '@/pubsub/pubsub.gateway';
+import { PubsubSubscriberService } from '@/pubsub/pubsub-subscriber.service';
+import { REDIS_CLIENT } from '@/redis/redis.module';
+import { Submission } from '@/submission/submission.entity';
+
+describe('PubsubSubscriberService — submissionId 단위 처리 큐', () => {
+  let service: PubsubSubscriberService;
+  let redis: RedisMock;
+
+  beforeEach(async () => {
+    redis = new RedisMock();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PubsubSubscriberService,
+        { provide: REDIS_CLIENT, useValue: redis },
+        { provide: getRepositoryToken(Submission), useValue: { findOne: jest.fn() } },
+        { provide: PubsubGateway, useValue: {} },
+        { provide: BattleGateway, useValue: {} },
+        { provide: BattleService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<PubsubSubscriberService>(PubsubSubscriberService);
+  });
+
+  it('같은 submissionId의 메시지는 순서대로 처리된다', async () => {
+    const processOrder: number[] = [];
+    const enqueue = (service as any).enqueue.bind(service);
+
+    enqueue('sub-1', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      processOrder.push(1);
+    });
+    enqueue('sub-1', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      processOrder.push(2);
+    });
+    enqueue('sub-1', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      processOrder.push(3);
+    });
+
+    await (service as any).queues.get('sub-1');
+
+    expect(processOrder).toEqual([1, 2, 3]);
+  });
+
+  it('서로 다른 submissionId의 메시지는 동시에 처리된다', async () => {
+    const startTimes: Record<string, number> = {};
+    const enqueue = (service as any).enqueue.bind(service);
+
+    enqueue('sub-1', async () => {
+      startTimes['sub-1'] = Date.now();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    enqueue('sub-2', async () => {
+      startTimes['sub-2'] = Date.now();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    await Promise.all([(service as any).queues.get('sub-1'), (service as any).queues.get('sub-2')]);
+
+    expect(Math.abs(startTimes['sub-1'] - startTimes['sub-2'])).toBeLessThan(50);
+  });
+
+  it('처리 완료 후 큐에서 메모리가 정리된다', async () => {
+    const enqueue = (service as any).enqueue.bind(service);
+
+    enqueue('sub-1', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    await (service as any).queues.get('sub-1');
+
+    expect((service as any).queues.has('sub-1')).toBe(false);
+  });
+});

--- a/apps/web/src/components/Battle/Player/CodeEditor.tsx
+++ b/apps/web/src/components/Battle/Player/CodeEditor.tsx
@@ -99,6 +99,8 @@ function CodeEditor() {
   const [pasteToastMessage, setPasteToastMessage] = useState<string | null>(null);
 
   const executionRef = useRef<ExecutionState | null>(null);
+  const pendingTotalRef = useRef<number | null>(null);
+  const finalPayloadRef = useRef<SubmissionResultPayload | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasEditedRef = useRef(false);
   const hasSyncedRef = useRef(false);
@@ -199,6 +201,41 @@ function CodeEditor() {
       hasSyncedRef.current = true;
     };
 
+    const tryFinalize = () => {
+      const total = pendingTotalRef.current;
+      if (total === null) return;
+
+      const received = useBattleExecutionStore.getState().testcaseResults.length;
+      if (received < total) return;
+
+      const payload = finalPayloadRef.current;
+      const execution = executionRef.current;
+      if (!execution || !payload) return;
+
+      clearExecutionTimeout();
+      execution.isCompleted = true;
+      executionRef.current = null;
+      pendingTotalRef.current = null;
+      finalPayloadRef.current = null;
+
+      if (payload.result) {
+        setProgress({
+          passed: payload.result.passed,
+          total: payload.result.total,
+          completed: payload.result.total,
+        });
+      }
+
+      const label = execution.type === 'TEST' ? '테스트 완료' : '채점 완료';
+      setStatusText(`${label} (${payload.status})`);
+
+      if (execution.type === 'TEST') {
+        setIsTesting(false);
+      } else {
+        setIsSubmitting(false);
+      }
+    };
+
     const handleTestcaseUpdate = (payload: TestcaseUpdatePayload) => {
       const execution = executionRef.current;
       // 실행 중이 아니거나 이미 완료된 경우 무시
@@ -212,17 +249,13 @@ function CodeEditor() {
         return;
       }
 
-      if (!execution.submissionId) {
-        execution.submissionId = incomingId;
-      }
-
       if (payload.progress) {
         setProgress(payload.progress);
       }
 
       upsertTestcaseResult({ ...payload.testcase, results: payload.results });
-
       setStatusText(execution.type === 'TEST' ? '테스트 진행 중' : '채점 진행 중');
+      tryFinalize();
     };
 
     const handleSubmissionResult = (payload: SubmissionResultPayload) => {
@@ -254,28 +287,12 @@ function CodeEditor() {
         return;
       }
 
-      // 타임아웃 정리
-      clearExecutionTimeout();
-
-      execution.isCompleted = true;
-
       if (payload.result) {
-        setProgress({
-          passed: payload.result.passed,
-          total: payload.result.total,
-          completed: payload.result.total,
-        });
+        pendingTotalRef.current = payload.result.total;
+        finalPayloadRef.current = payload;
       }
 
-      const label = execution.type === 'TEST' ? '테스트 완료' : '채점 완료';
-      setStatusText(`${label} (${payload.status})`);
-
-      executionRef.current = null;
-      if (execution.type === 'TEST') {
-        setIsTesting(false);
-      } else {
-        setIsSubmitting(false);
-      }
+      tryFinalize();
     };
 
     socket.on(BATTLE_EVENTS.CODE_UPDATED, handleCodeUpdated);

--- a/apps/web/test/CodeEditor.test.tsx
+++ b/apps/web/test/CodeEditor.test.tsx
@@ -31,13 +31,26 @@ vi.mock('@/components/Common/Toast', () => ({
   default: () => <div data-testid="toast" />,
 }));
 
-// Mock stores
-const mockSocketEmit = vi.fn();
+const { socketHandlers, testcaseResults, mockSocketEmit } = vi.hoisted(() => {
+  const socketHandlers: Record<string, (...args: any[]) => void> = {};
+  const testcaseResults: any[] = [];
+  const mockSocketEmit = vi.fn();
+  return { socketHandlers, testcaseResults, mockSocketEmit };
+});
+
 const mockConnect = vi.fn();
 
 vi.mock('@/stores/battleSocketStore', () => ({
   useBattleSocketStore: () => ({
-    socket: { connected: true, emit: mockSocketEmit, on: vi.fn(), off: vi.fn(), id: 'socket-id' },
+    socket: {
+      connected: true,
+      emit: mockSocketEmit,
+      on: (event: string, fn: (...args: any[]) => void) => {
+        socketHandlers[event] = fn;
+      },
+      off: vi.fn(),
+      id: 'socket-id',
+    },
     connect: mockConnect,
   }),
 }));
@@ -69,18 +82,23 @@ vi.mock('@/stores/battleProblemStore', () => ({
   }),
 }));
 
-const mockSetStatusText = vi.fn();
-vi.mock('@/stores/battleExecutionStore', () => ({
-  useBattleExecutionStore: () => ({
-    setStatusText: mockSetStatusText,
-    setProgress: vi.fn(),
-    setIsTesting: vi.fn(),
-    setIsSubmitting: vi.fn(),
-    setMode: vi.fn(),
-    setTestcaseResults: vi.fn(),
-    upsertTestcaseResult: vi.fn(),
-  }),
-}));
+vi.mock('@/stores/battleExecutionStore', () => {
+  function useBattleExecutionStore() {
+    return {
+      setStatusText: vi.fn(),
+      setProgress: vi.fn(),
+      setIsTesting: vi.fn(),
+      setIsSubmitting: vi.fn(),
+      setMode: vi.fn(),
+      setTestcaseResults: vi.fn(),
+      upsertTestcaseResult: (result: any) => {
+        testcaseResults.push(result);
+      },
+    };
+  }
+  useBattleExecutionStore.getState = () => ({ testcaseResults });
+  return { useBattleExecutionStore };
+});
 
 vi.mock('@/stores/battleProgressStore', () => ({
   useBattleProgressStore: () => ({
@@ -106,6 +124,8 @@ vi.mock('react-router-dom', () => ({
 describe('CodeEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    testcaseResults.length = 0;
+    Object.keys(socketHandlers).forEach((key) => delete socketHandlers[key]);
   });
 
   it('컴포넌트가 올바르게 렌더링되어야 한다', async () => {
@@ -172,6 +192,92 @@ describe('CodeEditor', () => {
         }),
         'socket-id',
       );
+    });
+  });
+});
+
+describe('테스트케이스 수신 완료 처리', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testcaseResults.length = 0;
+    Object.keys(socketHandlers).forEach((key) => delete socketHandlers[key]);
+    mockCreateDryRun.mockResolvedValue({});
+  });
+
+  it('FINAL_RESULT가 마지막 TC보다 먼저 도착해도 TC 누락 없이 3개 모두 처리된다', async () => {
+    render(<CodeEditor />);
+    const runButton = await screen.findByText('Run');
+
+    // 코드 실행 시작 → executionRef 초기화
+    fireEvent.click(runButton);
+    await waitFor(() => expect(mockCreateDryRun).toHaveBeenCalled());
+
+    const submissionId = 'sub-1';
+
+    // TC1, TC2 정상 수신
+    socketHandlers['testcase-update']?.({
+      submissionId,
+      testcase: { index: 1, status: 'WRONG_ANSWER' },
+      results: [],
+    });
+    socketHandlers['testcase-update']?.({
+      submissionId,
+      testcase: { index: 2, status: 'WRONG_ANSWER' },
+      results: [],
+    });
+
+    // FINAL_RESULT가 TC3보다 먼저 도착 (순서 역전)
+    socketHandlers['submission-result']?.({
+      submissionId,
+      result: { passed: 1, total: 3 },
+      status: 'WRONG_ANSWER',
+    });
+
+    // TC3 늦게 도착
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    socketHandlers['testcase-update']?.({
+      submissionId,
+      testcase: { index: 3, status: 'ACCEPTED' },
+      results: [],
+    });
+
+    await waitFor(() => {
+      expect(testcaseResults).toHaveLength(3);
+    });
+  });
+
+  it('정상 순서(TC1→TC2→TC3→FINAL_RESULT)에서도 3개 모두 처리된다', async () => {
+    render(<CodeEditor />);
+    const runButton = await screen.findByText('Run');
+
+    fireEvent.click(runButton);
+    await waitFor(() => expect(mockCreateDryRun).toHaveBeenCalled());
+
+    const submissionId = 'sub-1';
+
+    socketHandlers['testcase-update']?.({
+      submissionId,
+      testcase: { index: 1, status: 'WRONG_ANSWER' },
+      results: [],
+    });
+    socketHandlers['testcase-update']?.({
+      submissionId,
+      testcase: { index: 2, status: 'WRONG_ANSWER' },
+      results: [],
+    });
+    socketHandlers['testcase-update']?.({
+      submissionId,
+      testcase: { index: 3, status: 'ACCEPTED' },
+      results: [],
+    });
+    socketHandlers['submission-result']?.({
+      submissionId,
+      result: { passed: 1, total: 3 },
+      status: 'WRONG_ANSWER',
+    });
+
+    await waitFor(() => {
+      expect(testcaseResults).toHaveLength(3);
     });
   });
 });


### PR DESCRIPTION
## 🔍 PR 요약

- 코드 실행 시 마지막 테스트케이스가 간헐적으로 누락되는 race condition 버그 수정
- 백엔드: `submissionId` 단위 처리 큐로 emit 순서 보장
- 프론트엔드: `total` 카운트 기반 완료 처리로 순서 의존성 제거

## 🧾 관련 이슈

- close #282 

## 🛠️ 주요 변경 사항

- 백엔드: `submissionId` 단위 처리 큐 도입

  - 기존에는 Redis pub/sub 메시지 수신 시 `void this.handleMessage()`로 처리해 각 메시지가 병렬로 실행
  - TC3와 FINAL_RESULT가 거의 동시에 수신되면 DB 쿼리 응답 속도에 따라 emit 순서가 역전될 수 있는 것이 누락의 근본 원인

  → `submissionId`를 키로 하는 Promise 체인 큐 도입
  → 같은 `submissionId`의 메시지는 이전 처리가 완전히 끝난 후에 다음 처리를 시작하도록 직렬화되고, 처리 완료 후에는 `Map`에서 자동으로 정리

- 프론트엔드: `tryFinalize` 패턴으로 방어적 완료 처리

  - 기존에는 `FINAL_RESULT` 수신 즉시 `executionRef.current = null`로 초기화
  - 백엔드 emit 순서가 역전되어 FINAL이 TC3보다 먼저 도착하면, 이후 TC3 수신 시 `executionRef`가 이미 `null`이어서 처리가 드롭되는 구조

  → `FINAL_RESULT` 수신 시 즉시 완료 처리하는 대신 `total` 값을 `pendingTotalRef`에 저장
  → TC 수신 때마다 현재 수신된 TC 수와 `total`이 일치할 때 비로소 완료 처리하도록 변경

- 테스트 추가

  - 같은 `submissionId` 순서 보장 / 다른 `submissionId` 동시 처리 / 완료 후 메모리 정리
  - FINAL → TC3 순서 역전 시나리오 / TC1 → TC2 → TC3 → FINAL 정상 순서 시나리오

## 🧠 의도 및 배경

코드 실행 시 테스트케이스가 마지막 TC만 간헐적으로 화면에 표시되지 않는 버그, 원인은 백엔드에서 `void`로 병렬 실행된 메시지 처리가 emit 순서를 보장하지 못하는 것

백엔드에서 근본 원인을 제거하고, 프론트엔드에서도 순서에 의존하지 않는 방어적 처리를 추가해 이중으로 안전하게 동작하도록 수정
